### PR TITLE
cleanup: Start of no-implicit-bool compliance; use prefix-increment.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,3 +17,5 @@ jobs:
         run: make testprogs
       - name: Run tests
         run: make test
+      - name: Compile as C++
+        run: g++ -fsyntax-only -xc++ cmp.c

--- a/cmp.c
+++ b/cmp.c
@@ -24,6 +24,12 @@ THE SOFTWARE.
 
 #include "cmp.h"
 
+#if defined(__cplusplus) && __cplusplus >= 201103L
+#define CMP_NULL nullptr
+#else
+#define CMP_NULL NULL
+#endif /* C++11 */
+
 static const uint32_t cmp_version_ = 20;
 static const uint32_t cmp_mp_version_ = 5;
 
@@ -250,14 +256,14 @@ static bool write_byte(cmp_ctx_t *ctx, uint8_t x) {
 }
 
 static bool skip_bytes(cmp_ctx_t *ctx, size_t count) {
-  if (ctx->skip) {
+  if (ctx->skip != CMP_NULL) {
     return ctx->skip(ctx, count);
   }
   else {
-    uint8_t floor;
     size_t i;
 
-    for (i = 0; i < count; i++) {
+    for (i = 0; i < count; ++i) {
+      uint8_t floor;
       if (!ctx->read(ctx, &floor, sizeof(uint8_t))) {
         return false;
       }
@@ -952,7 +958,7 @@ bool cmp_write_float(cmp_ctx_t *ctx, float f) {
     char *fbuf = (char *)&f;
     size_t i;
 
-    for (i = 0; i < sizeof(float); i++)
+    for (i = 0; i < sizeof(float); ++i)
       swapped[i] = fbuf[sizeof(float) - i - 1];
 
     return ctx->write(ctx, swapped, sizeof(float));
@@ -971,7 +977,7 @@ bool cmp_write_double(cmp_ctx_t *ctx, double d) {
     char *dbuf = (char *)&d;
     size_t i;
 
-    for (i = 0; i < sizeof(double); i++)
+    for (i = 0; i < sizeof(double); ++i)
       swapped[i] = dbuf[sizeof(double) - i - 1];
 
     return ctx->write(ctx, swapped, sizeof(double));
@@ -2757,7 +2763,7 @@ bool cmp_skip_object(cmp_ctx_t *ctx, cmp_object_t *obj) {
           case CMP_TYPE_EXT8:
           case CMP_TYPE_EXT16:
           case CMP_TYPE_EXT32:
-            size++;
+            ++size;
             break;
           default:
             break;
@@ -2824,7 +2830,7 @@ bool cmp_skip_object_flat(cmp_ctx_t *ctx, cmp_object_t *obj) {
             case CMP_TYPE_EXT8:
             case CMP_TYPE_EXT16:
             case CMP_TYPE_EXT32:
-              size++;
+              ++size;
               break;
             default:
               break;
@@ -2901,7 +2907,7 @@ bool cmp_skip_object_no_limit(cmp_ctx_t *ctx) {
             case CMP_TYPE_EXT8:
             case CMP_TYPE_EXT16:
             case CMP_TYPE_EXT32:
-              size++;
+              ++size;
               break;
             default:
               break;
@@ -2963,7 +2969,7 @@ bool cmp_skip_object_limit(cmp_ctx_t *ctx, cmp_object_t *obj, uint32_t limit) {
       case CMP_TYPE_FIXMAP:
       case CMP_TYPE_MAP16:
       case CMP_TYPE_MAP32:
-        depth++;
+        ++depth;
 
         if (depth > limit) {
           obj->type = cmp_type;
@@ -2993,7 +2999,7 @@ bool cmp_skip_object_limit(cmp_ctx_t *ctx, cmp_object_t *obj, uint32_t limit) {
             case CMP_TYPE_EXT8:
             case CMP_TYPE_EXT16:
             case CMP_TYPE_EXT32:
-              size++;
+              ++size;
               break;
             default:
               break;


### PR DESCRIPTION
Semantics of postfix-increment are to return the value it had before the increment, encouraging code like `f(..., b++)`, which is better written as `f(..., b); ++b;` to avoid doing too many possibly mutating operations in one statement/expression.

I've put one of the no-implicit-bool cleanups in this PR, because it's the only one that requires `CMP_NULL` and an addition to the CI to continue supporting C++ as a compile target for cmp.c (it does today, and I don't want to break that). There are a number of implicit bool conversions, some of which are probably bugs, so I'll send a separate PR to fix those.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/cmp/12)
<!-- Reviewable:end -->
