### PR TITLE
cleanup: Align enum suffix with upstream.

### DIFF
--- a/cmp.c
+++ b/cmp.c
@@ -57,7 +57,7 @@ enum {
   FIXSTR_SIZE   = 0x1F
 };
 
-typedef enum cmp_error_t {
+typedef enum cmp_error_e {
   CMP_ERROR_NONE,
   CMP_ERROR_STR_DATA_LENGTH_TOO_LONG,
   CMP_ERROR_BIN_DATA_LENGTH_TOO_LONG,


### PR DESCRIPTION
We had renamed it because cimple doesn't support `_e`, but now it does.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/cmp/14)
<!-- Reviewable:end -->
